### PR TITLE
Update README.md to fix misspelling

### DIFF
--- a/weights/README.md
+++ b/weights/README.md
@@ -2,7 +2,7 @@
 
 All models are stored in `Hunyuan-GameCraft-1.0/weights` by default, and the file structure is as follows
 ```shell
-HunyuanVideo-Avatar
+Hunyuan-GameCraft-1.0
   ├──weights
   │  ├──gamecraft_models
   │  │  │──mp_rank_00_model_states.pt
@@ -21,7 +21,7 @@ HunyuanVideo-Avatar
   │  │  ├──openai_clip-vit-large-patch14
 ```
 
-## Download HunyuanVideo-Avatar model
+## Download Hunyuan-GameCraft-1.0 model
 To download the HunyuanCustom model, first install the huggingface-cli. (Detailed instructions are available [here](https://huggingface.co/docs/huggingface_hub/guides/cli).)
 
 ```shell
@@ -31,7 +31,7 @@ python -m pip install "huggingface_hub[cli]"
 Then download the model using the following commands:
 
 ```shell
-# Switch to the directory named 'HunyuanVideo-Avatar/weights'
+# Switch to the directory named 'Hunyuan-GameCraft-1.0/weights'
 cd Hunyuan-GameCraft-1.0/weights
 # Use the huggingface-cli tool to download HunyuanVideo-Avatar model in HunyuanVideo-Avatar/weights dir.
 # The download time may vary from 10 minutes to 1 hour depending on network conditions.


### PR DESCRIPTION
change to Hunyuan-GameCraft-1.0 instead of HunyuanVideo-Avatar