### PR TITLE
[Bug Fix] Fix SP and CPU offloading conflict

### DIFF
--- a/hymm_sp/diffusion/__init__.py
+++ b/hymm_sp/diffusion/__init__.py
@@ -24,6 +24,7 @@ def load_diffusion_pipeline(args, rank, vae, text_encoder, text_encoder_2, model
                                        progress_bar_config=progress_bar_config,
                                        args=args,
                                        )
-    pipeline = pipeline.to(device)
+    if not args.cpu_offload:
+        pipeline = pipeline.to(device)
 
     return pipeline

--- a/hymm_sp/modules/fp8_optimization.py
+++ b/hymm_sp/modules/fp8_optimization.py
@@ -1,3 +1,4 @@
+# modified from https://github.com/neuralmagic/AutoFP8/blob/main/auto_fp8/quantize.py
 import gc
 from typing import Tuple
 import copy

--- a/hymm_sp/modules/models.py
+++ b/hymm_sp/modules/models.py
@@ -163,7 +163,7 @@ class DoubleStreamBlock(nn.Module):
         v = torch.cat((img_v, txt_v), dim=1)
 
         # Compute attention.
-        if CPU_OFFLOAD or DISABLE_SP:
+        if DISABLE_SP:
             assert cu_seqlens_q.shape[0] == 2 * img.shape[0] + 1
 
             q, k, v = [
@@ -311,7 +311,7 @@ class SingleStreamBlock(nn.Module):
         if CPU_OFFLOAD: torch.cuda.empty_cache()
 
         # Compute attention.
-        if CPU_OFFLOAD or DISABLE_SP:
+        if DISABLE_SP:
             assert cu_seqlens_q.shape[0] == 2 * x.shape[0] + 1, \
                 f"cu_seqlens_q.shape:{cu_seqlens_q.shape}, x.shape[0]:{x.shape[0]}"
             # [b, s+l, a, d] -> [s+l, b, a, d]

--- a/hymm_sp/vae/autoencoder_kl_causal_3d.py
+++ b/hymm_sp/vae/autoencoder_kl_causal_3d.py
@@ -183,7 +183,7 @@ class AutoencoderKLCausal3D(ModelMixin, ConfigMixin, FromOriginalVAEMixin):
 
         # ============= parallism related code ===================
         world_size = cur_world_size()
-        self.parallel_decode = get_sequence_parallel_state()
+        self.parallel_decode = False if CPU_OFFLOAD else get_sequence_parallel_state()
         print("WORLD SIZE: ", world_size)
 
 

--- a/scripts/run_sample_batch_4090.sh
+++ b/scripts/run_sample_batch_4090.sh
@@ -7,11 +7,17 @@ checkpoint_path="/path/to/ckpts"
 current_time=$(date "+%Y.%m.%d-%H.%M.%S")
 modelname='Tencent_hunyuanGameCraft_720P'
 
-# disable sp and cpu offload
+# disable sp and enable cpu offload
 export DISABLE_SP=1
 export CPU_OFFLOAD=1
+export NUM_GPU=1
 
-torchrun --nnodes=1 --nproc_per_node=1 --master_port 29605 hymm_sp/sample_batch.py \
+# # enable both sp and cpu offload
+# export DISABLE_SP=0
+# export CPU_OFFLOAD=1
+# export NUM_GPU=8
+
+torchrun --nnodes=1 --nproc_per_node=${NUM_GPU} --master_port 29605 hymm_sp/sample_batch.py \
     --image-path "asset/village.png" \
     --prompt "A charming medieval village with cobblestone streets, thatched-roof houses, and vibrant flower gardens under a bright blue sky." \
     --add-neg-prompt "overexposed, low quality, deformation, a poor composition, bad hands, bad teeth, bad eyes, bad limbs, distortion, blurring, text, subtitles, static, picture, black border." \


### PR DESCRIPTION
This PR fixes the SP OOM issue ([#1](https://github.com/Tencent-Hunyuan/Hunyuan-GameCraft-1.0/issues/1)) occurring with CPU offloading enabled:

1. Adjust pipeline-to-device timing
2. Modify parallel_attention execution conditions
3. Disable VAE parallelism when both offloading and SP are on
4. Add script example

Due to CPU offloading overhead, SP8 yields ~2x speedup.